### PR TITLE
docs: update enonic-nextxp-integration from latest Enonic docs

### DIFF
--- a/skills/enonic-nextxp-integration/SKILL.md
+++ b/skills/enonic-nextxp-integration/SKILL.md
@@ -34,13 +34,18 @@ metadata:
 2. Read `references/examples.md` for complete content type mapping examples including queries, views, and processors.
 3. For each Enonic content type that needs a custom rendering:
    a. Create a Guillotine GraphQL query function in `src/components/queries/` that fetches the fields specific to that content type using type introspection (`... on AppName_ContentTypeName`).
-   b. Create a React view component in `src/components/views/` that accepts `FetchContentResult` props and renders the fetched data.
-   c. Register both in `src/components/_mappings.ts` using `ComponentRegistry.addContentType()`.
+   b. For content types with HTML area (rich text) fields, use `richTextQuery(fieldName)` from `@enonic/nextjs-adapter` to generate the query fragment. See `references/nextxp-reference.md` for the rich text rendering section.
+   c. Create a React view component in `src/components/views/` that accepts `FetchContentResult` props and renders the fetched data. Use `RichTextView` from `@enonic/nextjs-adapter/views/RichTextView` for HTML area fields.
+   d. Register both in `src/components/_mappings.ts` using `ComponentRegistry.addContentType()`.
 4. For page components (pages, parts, layouts):
    a. Define the component XML in the Enonic app under `src/main/resources/site/pages/`, `parts/`, or `layouts/`.
-   b. Create a corresponding React component in `src/components/pages/`, `parts/`, or `layouts/`.
+   b. Create a corresponding React component in `src/components/pages/`, `parts/`, or `layouts/`. Use `LayoutProps` for layouts and the named `RegionView` export for individual region rendering.
    c. Register using `ComponentRegistry.addPage()`, `ComponentRegistry.addPart()`, or `ComponentRegistry.addLayout()`.
-5. Use `APP_NAME` and `APP_NAME_UNDERSCORED` imports from `@enonic/nextjs-adapter` to keep content type references dynamic.
+5. For macros (custom components within rich text):
+   a. Create a React component in `src/components/macros/` that accepts `MacroProps`.
+   b. Register with `ComponentRegistry.addMacro()` using `configQuery` for form values. Register macros **before** any component that uses `RichTextView`.
+   c. See `references/examples.md` for a complete macro example.
+6. Use `APP_NAME` and `APP_NAME_UNDERSCORED` imports from `@enonic/nextjs-adapter` to keep content type references dynamic.
 
 **Step 4: Configure Guillotine data fetching**
 1. Read `references/nextxp-reference.md` for the Guillotine query structure and variable passing.
@@ -79,7 +84,8 @@ metadata:
 2. Verify that standalone Next.js rendering works at `http://localhost:3000` with published content.
 3. Verify Content Studio preview renders correctly for both draft and published content.
 4. Test content type mappings by visiting content URLs and confirming custom views render.
-5. Run the workspace build (`npm run build`) to catch TypeScript or build errors.
+5. Use `validateData()` from `@enonic/nextjs-adapter` in the page handler to catch invalid content responses. See `references/nextxp-reference.md` for the SSG page handler pattern.
+6. Run the workspace build (`npm run build`) to catch TypeScript or build errors.
 
 ## Error Handling
 * If Content Studio preview shows a blank page, read `references/troubleshooting.md` for preview proxy diagnostics, token mismatch detection, and CORS issues.

--- a/skills/enonic-nextxp-integration/references/compatibility.md
+++ b/skills/enonic-nextxp-integration/references/compatibility.md
@@ -33,9 +33,14 @@ Version requirements and compatibility notes for the Next.js + Enonic XP integra
 - The Guillotine app is automatically installed when creating a sandbox with `enonic project create`.
 
 ### @enonic/nextjs-adapter
-- Provides `ComponentRegistry`, `FetchContentResult`, `PageProps`, `PartProps`, and utility functions.
-- Exports `APP_NAME` and `APP_NAME_UNDERSCORED` derived from `ENONIC_APP_NAME` env variable.
+- Provides `ComponentRegistry`, `FetchContentResult`, `PageProps`, `PartProps`, `LayoutProps`, `MacroProps`, and utility functions.
+- Exports `APP_NAME`, `APP_NAME_UNDERSCORED`, and `APP_NAME_DASHED` derived from `ENONIC_APP_NAME` env variable.
+- Exports `richTextQuery(fieldName)` to generate GraphQL fragments for HTML area fields.
+- Exports `validateData(props)` to validate content responses and throw `notFound()` for invalid data.
 - Handles draft/master branch switching automatically based on preview mode state.
+- Server-side functions (`fetchContent`, `fetchContentPathsForAllLocales`) are imported from `@enonic/nextjs-adapter/server`.
+- Client-side functions (`useLocaleContext`, `LocaleContextProvider`) are imported from `@enonic/nextjs-adapter/client`.
+- Views are imported from individual files under `@enonic/nextjs-adapter/views/` (e.g., `MainView`, `RichTextView`, `Region`, `StaticContent`).
 
 ### GraphQL Type Naming Convention
 - Content type names in GraphQL introspection follow: dots replaced with underscores, final segment capitalized.

--- a/skills/enonic-nextxp-integration/references/examples.md
+++ b/skills/enonic-nextxp-integration/references/examples.md
@@ -318,3 +318,171 @@ query($path:ID!){
   }
 }
 ```
+
+## Example 7: Rich Text Content Type with RichTextView
+
+### Rich Text Query (src/components/queries/getPersonWithBio.ts)
+
+Uses `richTextQuery()` to generate the GraphQL fragment for an HTML area field:
+
+```typescript
+import {APP_NAME_UNDERSCORED, richTextQuery} from '@enonic/nextjs-adapter';
+
+const getPersonWithBio = () => `
+query($path:ID!){
+  guillotine {
+    get(key:$path) {
+      displayName
+      ... on ${APP_NAME_UNDERSCORED}_Person {
+        data {
+          ${richTextQuery('bio')}
+          dateofbirth
+          photos {
+            ... on media_Image {
+              imageUrl: imageUrl(type: absolute, scale: "width(500)")
+              attachments {
+                name
+              }
+            }
+          }
+        }
+      }
+      parent {
+        _path(type: siteRelative)
+      }
+    }
+  }
+}`;
+
+export default getPersonWithBio;
+```
+
+### React View with RichTextView (src/components/views/PersonWithBio.tsx)
+
+```typescript
+import React from 'react';
+import {FetchContentResult, getUrl, I18n} from '@enonic/nextjs-adapter';
+import Link from 'next/link';
+import RichTextView from '@enonic/nextjs-adapter/views/RichTextView';
+
+const PersonWithBio = (props: FetchContentResult) => {
+    const {displayName, data, parent} = props.data?.get as any;
+    const {bio, photos} = data;
+    const meta = props.meta;
+
+    return (
+        <>
+            <div>
+                <h2>{displayName}</h2>
+                <RichTextView data={bio} meta={meta}/>
+                {photos.map((photo: any, i: number) => (
+                    <img key={i}
+                         src={getUrl(photo.imageUrl, meta)}
+                         title={getTitle(photo, displayName)}
+                         alt={getTitle(photo, displayName)}
+                         width="500"
+                    />
+                ))}
+            </div>
+            <p>
+                <Link href={getUrl(`/${parent._path}`, meta)}>
+                    {I18n.localize('back')}
+                </Link>
+            </p>
+        </>
+    );
+};
+
+export default PersonWithBio;
+
+function getTitle(photo: any, displayName: string) {
+    return (photo.attachments || [])[0]?.name || displayName;
+}
+```
+
+### Registration
+
+```typescript
+import getPersonWithBio from './queries/getPersonWithBio';
+import PersonWithBio from './views/PersonWithBio';
+
+ComponentRegistry.addContentType(`${APP_NAME}:person`, {
+    query: getPersonWithBio,
+    view: PersonWithBio
+});
+```
+
+## Example 8: Macro Component (FactBox)
+
+### Macro Component (src/components/macros/FactBox.tsx)
+
+```typescript
+import type {MacroProps} from '@enonic/nextjs-adapter';
+import React from 'react';
+
+const FactBox = ({name, children, config, meta}: MacroProps) => {
+    const header = config.header?.length ? config.header : 'Fact Box';
+    return (
+        <ins style={{
+            backgroundColor: 'rgb(235, 249, 249)',
+            display: 'block',
+            textDecoration: 'none',
+            borderRadius: '2px',
+            padding: '10px 20px',
+            margin: '20px auto',
+            width: '75%'
+        }}>
+            <strong>{header}</strong>
+            {children}
+        </ins>
+    );
+};
+
+export default FactBox;
+```
+
+### Registration (must be before components using RichTextView)
+
+```typescript
+import FactBox from './macros/FactBox';
+
+// Register macros first in _mappings.ts
+ComponentRegistry.addMacro(`${APP_NAME}:factbox`, {
+    view: FactBox,
+    configQuery: '{ header }'
+});
+```
+
+## Example 9: Layout with RegionView for Individual Regions
+
+### Layout Component (src/components/layouts/TwoColumnLayout.tsx)
+
+```typescript
+import type {LayoutProps} from '@enonic/nextjs-adapter';
+import React from 'react';
+import {RegionView} from '@enonic/nextjs-adapter/views/Region';
+
+const TwoColumnLayout = (props: LayoutProps) => {
+    const regions = props.layout.regions;
+    const {common, meta} = props;
+
+    return (
+        <div style={{display: 'flex', gap: '10px', flexWrap: 'wrap'}}>
+            <RegionView name="left" components={regions['left']?.components} common={common} meta={meta}/>
+            <RegionView name="right" components={regions['right']?.components} common={common} meta={meta}/>
+        </div>
+    );
+};
+
+export default TwoColumnLayout;
+```
+
+### Registration
+
+```typescript
+import TwoColumnLayout from './layouts/TwoColumnLayout';
+
+ComponentRegistry.addLayout(`${APP_NAME}:2-column`, {
+    view: TwoColumnLayout
+});
+```

--- a/skills/enonic-nextxp-integration/references/nextxp-reference.md
+++ b/skills/enonic-nextxp-integration/references/nextxp-reference.md
@@ -236,11 +236,24 @@ Key adapter imports:
 - `FetchContentResult` — props type for content type views.
 - `PageProps` — props type for page components.
 - `PartProps` — props type for part components.
+- `LayoutProps` — props type for layout components.
+- `MacroProps` — props type for macro components.
 - `getUrl(path, meta)` — resolves URLs for both standalone and preview modes.
 - `getAsset(path, meta)` — resolves static asset URLs.
+- `richTextQuery(fieldName)` — generates the GraphQL query fragment for HTML area input types.
+- `validateData(props)` — validates `FetchContentResult`, throws errors or `notFound()` for invalid data.
 - `I18n.localize(key)` — localized string lookup from phrase files.
 - `APP_NAME` — fully qualified app name from env config.
 - `APP_NAME_UNDERSCORED` — app name with dots replaced by underscores for GraphQL introspection.
+- `APP_NAME_DASHED` — app name with dashes instead of dots.
+
+Server-side imports from `@enonic/nextjs-adapter/server`:
+- `fetchContent(context)` — main method for querying content by path with component queries, page structure, and runtime info.
+- `fetchContentPathsForAllLocales(path)` — loads all content paths for SSG across locales.
+
+Client-side imports from `@enonic/nextjs-adapter/client`:
+- `LocaleContextProvider` — React context provider for locale.
+- `useLocaleContext()` — hook returning `{ locale, localize, setLocale }` for client-side components.
 
 ## Page Components with Regions
 
@@ -274,6 +287,33 @@ const MainPage = (props: PageProps) => {
 
 export default MainPage;
 ```
+
+## Layout Components with Individual Region Rendering
+
+Layouts use `LayoutProps` and the named `RegionView` export (not the default `RegionsView`) to render individual regions:
+
+```typescript
+import type {LayoutProps} from '@enonic/nextjs-adapter';
+import {RegionView} from '@enonic/nextjs-adapter/views/Region';
+
+const TwoColumnLayout = (props: LayoutProps) => {
+    const regions = props.layout.regions;
+    const {common, meta} = props;
+
+    return (
+        <div style={{display: 'flex', gap: '10px'}}>
+            <RegionView name="left" components={regions['left']?.components} common={common} meta={meta}/>
+            <RegionView name="right" components={regions['right']?.components} common={common} meta={meta}/>
+        </div>
+    );
+};
+
+export default TwoColumnLayout;
+```
+
+Key distinction:
+- `RegionsView` (default export from `@enonic/nextjs-adapter/views/Region`) — renders a named region from a page. Used in page components.
+- `RegionView` (named export from `@enonic/nextjs-adapter/views/Region`) — renders an individual region by its components array. Used in layout components.
 
 ## Preview Mode Architecture
 
@@ -314,3 +354,160 @@ ENONIC_API=https://<account>-<solution>-<env>.enonic.net/api
 ENONIC_API_TOKEN=<production-secret>
 ENONIC_MAPPINGS=en:intro/hmdb,no:intro-no/hmdb
 ```
+
+## Rich Text Rendering
+
+Enonic content types may include HTML area fields (rich text). To render these correctly — including embedded images, links, and macros — use the `richTextQuery` helper and `RichTextView` component.
+
+### Querying Rich Text
+
+Use `richTextQuery(fieldName)` from `@enonic/nextjs-adapter` to generate the GraphQL fragment for an HTML area field. This generates the required query including image, link, and macro metadata:
+
+```typescript
+import {APP_NAME_UNDERSCORED, richTextQuery} from '@enonic/nextjs-adapter';
+
+const getPersonWithBio = () => `
+query($path:ID!){
+  guillotine {
+    get(key:$path) {
+      displayName
+      ... on ${APP_NAME_UNDERSCORED}_Person {
+        data {
+          ${richTextQuery('bio')}
+          photos {
+            ... on media_Image {
+              imageUrl: imageUrl(type: absolute, scale: "width(500)")
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+export default getPersonWithBio;
+```
+
+The query function **must** be a function (not a static string) when using `richTextQuery`, because it depends on registered macros being available at execution time.
+
+### Rendering Rich Text
+
+Use the `RichTextView` component from `@enonic/nextjs-adapter/views/RichTextView`:
+
+```typescript
+import RichTextView from '@enonic/nextjs-adapter/views/RichTextView';
+
+// In a view component:
+<RichTextView data={bio} meta={meta} tag="section" className="bio"/>
+```
+
+Props:
+- `data` — rich text data object returned by `richTextQuery`.
+- `meta` — `MetaData` from `FetchContentResult`.
+- `tag` — HTML wrapper tag (default: `'div'`). Optional.
+- `className` — CSS class for the wrapper. Optional.
+- `renderMacroInEditMode` — whether macros render in Content Studio edit mode (default: `true`). Optional.
+- `customReplacer` — function for custom element processing (not invoked for image, link, macro nodes). Optional.
+
+## Macro Registration
+
+Macros are custom components embedded within rich text fields. They follow the same registration pattern as other components but use `ComponentRegistry.addMacro()`.
+
+```typescript
+import {ComponentRegistry, APP_NAME} from '@enonic/nextjs-adapter';
+import FactBox from './macros/FactBox';
+
+ComponentRegistry.addMacro(`${APP_NAME}:factbox`, {
+    view: FactBox,
+    configQuery: '{ header }'
+});
+```
+
+Key rules:
+- Macros use `configQuery` instead of `query`. The `configQuery` operates on the macro's form values, and the result is available in the React component's `config` prop.
+- The macro body is implicitly passed to the component as `children`.
+- Macros **must be registered before** any component that uses `RichTextView`. Best practice: register macros at the top of `_mappings.ts`.
+- Macro React components receive `MacroProps`: `{ name, children, config, meta }`.
+
+## Static Site Generation (SSG)
+
+### Page Handler Pattern
+
+The catch-all page handler at `src/app/[locale]/[[...contentPath]]/page.tsx` controls rendering and SSG:
+
+```typescript
+import {FetchContentResult, validateData} from '@enonic/nextjs-adapter';
+import {fetchContent, fetchContentPathsForAllLocales} from '@enonic/nextjs-adapter/server';
+import MainView from '@enonic/nextjs-adapter/views/MainView';
+import '../../../components/_mappings';
+import {draftMode} from 'next/headers';
+
+export const revalidate = 3600;
+
+export default async function Page({params}: {params: Promise<PageProps>}) {
+    const {isEnabled: draft} = await draftMode();
+    const resolvedParams = await params;
+
+    const data: FetchContentResult = await fetchContent({
+        ...resolvedParams,
+        contentPath: resolvedParams.contentPath || []
+    });
+
+    validateData(data);
+
+    return <MainView {...data}/>;
+}
+
+export async function generateStaticParams(): Promise<any[]> {
+    return await fetchContentPathsForAllLocales('${site}/');
+}
+
+export async function generateMetadata({params}: {params: Promise<PageProps>}): Promise<Metadata> {
+    const resolvedParams = await params;
+    const {common} = await fetchContent({
+        ...resolvedParams,
+        contentPath: resolvedParams.contentPath || []
+    });
+    return {title: common?.get?.displayName || 'Not found'};
+}
+```
+
+Key points:
+- `validateData(data)` validates the response and throws `notFound()` for invalid data.
+- `generateStaticParams()` uses `fetchContentPathsForAllLocales()` to pre-render pages at build time.
+- `generateMetadata()` provides dynamic page titles from content.
+- `revalidate` controls ISR (Incremental Static Regeneration) interval in seconds.
+- `draftMode()` detects Content Studio preview mode, which bypasses static pages for fresh draft content.
+- The Next.XP app automatically triggers revalidation of pages when content is published.
+
+### StaticContent Component
+
+Use `StaticContent` from `@enonic/nextjs-adapter/views/StaticContent` to disable client-side hydration conditionally (e.g., in Content Studio edit mode):
+
+```typescript
+import StaticContent from '@enonic/nextjs-adapter/views/StaticContent';
+
+<StaticContent condition={isEdit}>
+    <Header meta={meta}/>
+    <main>{children}</main>
+    <Footer/>
+</StaticContent>
+```
+
+## Client-Side Locale Access
+
+In client-side components, use the `useLocaleContext` hook from `@enonic/nextjs-adapter/client`:
+
+```typescript
+'use client';
+
+import {useLocaleContext} from '@enonic/nextjs-adapter/client';
+
+export default function ClientSideComponent() {
+    const {locale, localize, setLocale} = useLocaleContext();
+    const localizedText = localize('text.key');
+    // ...
+}
+```
+
+This requires a `LocaleContextProvider` wrapper in the layout (included in the nextxp-template).


### PR DESCRIPTION
Add coverage for rich text rendering (richTextQuery, RichTextView), macro registration (ComponentRegistry.addMacro), layout types (LayoutProps, RegionView), SSG patterns (validateData, generateStaticParams, draftMode), and client-side i18n (useLocaleContext). Update adapter exports in compatibility matrix.

Sources:
- https://developer.enonic.com/docs/next.xp/stable/rich-text
- https://developer.enonic.com/docs/next.xp/stable/macros
- https://developer.enonic.com/docs/next.xp/stable/layouts
- https://developer.enonic.com/docs/next.xp/stable/static
- https://developer.enonic.com/docs/next.xp/stable/i18n
- https://github.com/enonic/nextjs-adapter (adapter README)