### PR TITLE
docs: update enonic-guillotine-query-builder from latest Enonic docs

### DIFF
--- a/skills/enonic-guillotine-query-builder/SKILL.md
+++ b/skills/enonic-guillotine-query-builder/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 **Step 1: Scan the workspace for existing Guillotine usage**
 1. Execute `node scripts/find-guillotine-targets.mjs .` to inventory files containing Guillotine markers (query strings, library imports, endpoint references).
 2. If a Node runtime is unavailable, search the workspace manually for `guillotine`, `queryDsl`, `queryDslConnection`, or `/lib/guillotine` in `.ts`, `.js`, `.graphql`, and `.gql` files.
-3. Note the Guillotine version in use: if `query(query: "...")` string-based fields are found, the project uses the deprecated 5.x-style API; if `queryDsl` / `queryDslConnection` are found, the project uses 6.x+ DSL.
+3. Note the Guillotine version in use: if `query(query: "...")` string-based fields are found, the project uses the deprecated 5.x-style API; if `queryDsl` / `queryDslConnection` are found, the project uses 6.x+ DSL. Check for `exports.extensions` in `guillotine/guillotine.js` to detect Guillotine 7 Extensions API usage.
 4. If both styles coexist, flag the deprecated usage for migration.
 
 **Step 2: Load the Guillotine API reference**
@@ -34,7 +34,7 @@ metadata:
 1. Derive the GraphQL type name from the content type descriptor by replacing dots (`.`) and colons (`:`) with underscores (`_`), and removing hyphens (`-`) while capitalizing the following letter. The first letter of each segment after a colon is capitalized. Example: `com.enonic.app.myapp:BlogPost` → `com_enonic_app_myapp_BlogPost`. For built-in types: `portal:template-folder` → `portal_TemplateFolder`.
 2. Use an inline fragment to access the type-specific `data` field: `... on <GraphQLTypeName> { data { ... } }`.
 3. For content references (ContentSelector, ImageSelector, MediaSelector), follow the reference with a nested inline fragment on the target type.
-4. For RichText / HtmlArea fields, include `processedHtml` and optionally `links`, `images`, `macros` sub-fields. Use the `processHtml` input argument for absolute URLs or srcset widths.
+4. For RichText / HtmlArea fields, include `processedHtml` and optionally `links`, `images`, `macros` sub-fields. Use the `processHtml` input argument for absolute URLs, srcset widths (`imageWidths`), or responsive sizes (`imageSizes`).
 
 **Step 5: Build query filters and sorting**
 1. Use Query DSL input types. Each `QueryDSLInput` must contain exactly one expression field.
@@ -66,7 +66,8 @@ metadata:
 3. Ensure `QueryDSLInput` objects contain exactly one expression field.
 4. Verify `DSLExpressionValueInput` objects contain exactly one value type field.
 5. Check that aggregation and highlight are only used on connection variants.
-6. Read `references/troubleshooting.md` if the query returns unexpected nulls, empty results, or type errors.
+6. For Guillotine 7+ projects, verify `pageUrl` / `mediaUrl` / `imageUrl` / `attachmentUrl` use `Json` type for `params` argument, not `String`.
+7. Read `references/troubleshooting.md` if the query returns unexpected nulls, empty results, or type errors.
 
 ## Error Handling
 * If `get` returns null, verify the key is a valid content path or ID and that the correct branch (draft vs master) is targeted.

--- a/skills/enonic-guillotine-query-builder/references/compatibility.md
+++ b/skills/enonic-guillotine-query-builder/references/compatibility.md
@@ -2,12 +2,48 @@
 
 Version differences and migration notes between major Guillotine releases.
 
-## Guillotine 6.x (Current Stable)
+## Guillotine 7.x (Current Stable)
+
+Requires **XP 7.14.0** or higher. Guillotine 7 is a full rewrite from JavaScript to Java.
+
+### Key Changes from 6.x
+
+- **Java-based engine**: Fully reimplemented from JavaScript to Java for improved performance and stability.
+- **Extensions API**: New `exports.extensions` pattern in `guillotine/guillotine.js` for extending the GraphQL schema with custom types, input types, enums, unions, interfaces, and custom resolvers. Replaces the older `creationCallbacks`-only approach.
+- **Absolute URLs by default**: All `media` and `content` URLs in `pageUrl`, `imageUrl`, `mediaUrl`, `attachmentUrl`, and `processedHtml` are now `absolute` (server) URLs generated in endpoint context.
+- **`params` type changed**: The `params` argument for `pageUrl`, `mediaUrl`, `imageUrl`, and `attachmentUrl` is now `Json` instead of `String`.
+- **Subscriptions removed**: GraphQL subscriptions are no longer supported.
+- **Site configuration removed**: `siteConfig` is no longer available from `dataAsJson`, `site`, or `portal_Site.dataAsJson` fields.
+
+### Breaking Changes in 7.0
+
+| Change | Impact | Migration |
+|---|---|---|
+| Subscriptions removed | No GraphQL subscription support | Implement a custom solution outside Guillotine |
+| `params` type changed to `Json` | URL field `params` arguments break if passed as `String` | Update `pageUrl`, `mediaUrl`, `imageUrl`, `attachmentUrl` calls to use `Json` type |
+| Site configuration removed | Cannot read `siteConfig` from content fields | Obtain site config through alternative means |
+| Absolute URLs by default | All generated URLs are absolute server-relative | Adjust client URL handling if previously relying on relative URLs |
+
+### Guillotine 7 Update 1
+
+- **`siteKey` argument**: New optional `siteKey` argument on the `guillotine` field, usable instead of the `X-Guillotine-SiteKey` header.
+- **NPM type definitions**: Guillotine types available on NPM as `@enonic-types/guillotine`. Install with `npm install @enonic/guillotine-types --save-dev`.
+- **`modifyUnknownFields` config**: New option to control handling of unknown fields (throw error, ignore, or log warning).
+
+### Guillotine 7 Update 2
+
+- **CORS support**: Built-in Cross-Origin Resource Sharing support with configurable allowed origins, methods, and headers. Enabled by default.
+
+### Guillotine 7 Update 3
+
+- **`maxQueryTokens` config**: Configurable maximum number of raw tokens the parser accepts per query. Defaults to `15000`.
+
+## Guillotine 6.x
 
 ### Key Changes from 5.x
 
 - **Project-level API**: Guillotine mounts at the project root (`/site/<project>/<branch>`). Site-level deployment is removed.
-- **Dynamic site context**: Set `X-Guillotine-SiteKey` header or use `siteKey` argument on the `guillotine` field for site-scoped queries.
+- **Dynamic site context**: Set `X-Guillotine-SiteKey` header for site-scoped queries.
 - **Global schema**: The GraphQL schema is generated from all installed apps across the instance, not per-site.
 - **Typed x-data**: eXtra Data schemas are fully typed and grouped by application key.
 - **Content Studio Playground**: Embedded GraphQL API browser available directly in Content Studio.
@@ -51,7 +87,7 @@ Version differences and migration notes between major Guillotine releases.
 }
 ```
 
-### After (6.x with queryDsl)
+### After (6.x+ with queryDsl)
 
 ```graphql
 {

--- a/skills/enonic-guillotine-query-builder/references/guillotine-reference.md
+++ b/skills/enonic-guillotine-query-builder/references/guillotine-reference.md
@@ -3,6 +3,8 @@
 Condensed reference for composing Guillotine queries against Enonic XP.
 Source: https://developer.enonic.com/docs/guillotine/stable/api
 
+Guillotine 7.x is the current stable release (requires XP 7.14.0+).
+
 ## Entry Point
 
 Every query starts with the `guillotine` root field:
@@ -15,7 +17,7 @@ Every query starts with the `guillotine` root field:
 }
 ```
 
-Pass `siteKey` when working in a site context:
+Pass `siteKey` when working in a site context (Guillotine 7.1+):
 
 ```graphql
 {
@@ -23,7 +25,7 @@ Pass `siteKey` when working in a site context:
 }
 ```
 
-Or set the HTTP header `X-Guillotine-SiteKey: <IdOrPathToSite>`.
+Or set the HTTP header `X-Guillotine-SiteKey: <IdOrPathToSite>` (6.x+).
 
 ## HeadlessCms Fields (Query Operations)
 
@@ -61,20 +63,28 @@ All content types share these fields. Custom content types add a `data` field.
 | `_path(type: ContentPathType)` | `String!` | Full or site-relative path |
 | `displayName` | `String` | Display name |
 | `type` | `String` | Content type descriptor |
+| `creator` | `PrincipalKey` | Content creator |
+| `modifier` | `PrincipalKey` | Last content modifier |
+| `owner` | `PrincipalKey` | Content owner |
 | `createdTime` | `String` | ISO datetime |
 | `modifiedTime` | `String` | ISO datetime |
 | `language` | `String` | Language code |
 | `valid` | `Boolean` | Content validity |
 | `hasChildren` | `Boolean` | Has children |
 | `dataAsJson` | `JSON` | Raw data as JSON |
+| `xAsJson` | `JSON` | Extra data as JSON |
+| `pageAsJson` | `JSON` | Page specific information |
 | `parent` | `Content` | Parent content |
+| `site` | `portal_Site` | Link to nearest site |
 | `children(offset, first, sort)` | `[Content]` | Direct children |
 | `childrenConnection(after, first, sort)` | `ContentConnection` | Children as a connection |
 | `publish` | `PublishInfo` | from, to, first timestamps |
 | `attachments` | `[Attachment]` | File attachments |
 | `components` | `[Component]` | Page components (flattened) |
-| `pageUrl(type, params)` | `String` | Generated URL for this content |
+| `pageUrl(type, params: Json)` | `String` | Generated URL for this content. `params` is `Json` type in Guillotine 7+ |
+| `pageTemplate` | `Content` | Related page template content |
 | `x` | `[ExtraData]` | eXtra Data |
+| `permissions` | `Permissions` | Content permissions |
 
 ## Inline Fragments for Custom Types
 
@@ -167,8 +177,10 @@ Example:
 ### TermDSLExpressionInput
 
 ```graphql
-term: { field: "type", value: { string: "com.enonic.app.myapp:Post" } }
+term: { field: "type", value: { string: "com.enonic.app.myapp:Post" }, boost: 2.0 }
 ```
+
+Supports `boost` for relevance scoring.
 
 ### RangeDSLExpressionInput
 
@@ -180,10 +192,16 @@ range: {
 }
 ```
 
+Supports `boost` for relevance scoring.
+
 ### DSLExpressionValueInput
 
 Exactly one type field:
 `string`, `double`, `long`, `boolean`, `localDate`, `localDateTime`, `localTime`, `instant`
+
+### Other DSL Expression Inputs
+
+All DSL expression types (`like`, `in`, `exists`, `fulltext`, `ngram`, `stemmed`, `matchAll`, `pathMatch`) support the `boost` parameter for relevance scoring. `fulltext`, `ngram`, and `stemmed` accept `fields`, `query`, and `operator` (`OR` or `AND`). `stemmed` also requires `language`.
 
 ## SortDslInput
 
@@ -196,7 +214,7 @@ Exactly one type field:
 
 ## Aggregation Input Types
 
-Pass via `aggregations` on `queryDslConnection`. Each `AggregationInput` takes a `name` and exactly one aggregation type:
+Pass via `aggregations` on `queryDslConnection`. Each `AggregationInput` takes a `name`, exactly one aggregation type, and an optional `subAggregations` array for nested aggregations:
 
 | Type | Purpose |
 |---|---|
@@ -208,6 +226,8 @@ Pass via `aggregations` on `queryDslConnection`. Each `AggregationInput` takes a
 | `getDistance` | Geo-distance buckets |
 | `min` / `max` / `count` | Simple single-value aggregations |
 
+Each aggregation also accepts `subAggregations: [AggregationInput]` for nesting.
+
 Results are returned in `aggregationsAsJson`.
 
 ## Highlight Input Types
@@ -216,12 +236,18 @@ Pass via `highlight` on `queryDslConnection`:
 
 | Field | Default |
 |---|---|
-| `encoder` | `default` (no encoding) |
+| `encoder` | `default` (no encoding). Use `html` for HTML encoding |
+| `tagsSchema` | Unset. Set to `styled` for built-in tag schema |
+| `fragmenter` | `span`. Alternative: `simple` |
 | `fragmentSize` | `100` |
+| `noMatchSize` | `0` (nothing returned if no match) |
 | `numberOfFragments` | `5` |
+| `order` | `none`. Set to `score` to sort by relevance |
 | `preTag` / `postTag` | `<em>` / `</em>` |
 | `requireFieldMatch` | `true` |
 | `properties` | Array of `HighlightPropertiesInputType` with `propertyName` |
+
+Each `HighlightPropertiesInputType` accepts per-property overrides: `propertyName` (required), `fragmenter`, `fragmentSize`, `noMatchSize`, `numberOfFragments`, `order`, `preTag`, `postTag`, `requireFieldMatch`.
 
 Results are returned in `highlightAsJson`.
 
@@ -233,18 +259,25 @@ Returned for HtmlArea fields:
 |---|---|
 | `raw` | Unprocessed HTML |
 | `processedHtml` | Processed HTML with resolved links, images, macros |
+| `macrosAsJson` | Detected macros as JSON array (alternative to `macros` field) |
 | `macros` | Detected macros with ref, name, descriptor, config |
-| `images` | Detected images with ref, content, style |
-| `links` | Detected links with ref, uri, media, content |
+| `images` | Detected images with ref, content, style (name, aspectRatio, filter) |
+| `links` | Detected links with ref, uri, media (intent, content), content |
 
-Use `processHtml` input argument for image width srcset generation:
+The `links` field distinguishes between media and content links:
+- `media` — non-null for media links; includes `intent` (`download` or `inline`) and `content`
+- `content` — non-null for content links; null for media links
+
+Use `processHtml` input argument for image processing:
 
 ```graphql
-body(processHtml: { imageWidths: [600, 992], type: absolute }) {
+body(processHtml: { imageWidths: [600, 992], imageSizes: "(max-width: 600px) 100vw, 50vw", type: absolute }) {
   processedHtml
   images { ref }
 }
 ```
+
+`imageSizes` specifies image widths for specific browser resolutions in the format `(media-condition) width`, comma-separated.
 
 ## Key Enum Types
 
@@ -252,6 +285,10 @@ body(processHtml: { imageWidths: [600, 992], type: absolute }) {
 |---|---|
 | `UrlType` | `server`, `absolute` |
 | `ContentPathType` | `siteRelative` |
+| `MediaIntentType` | `download`, `inline` |
 | `DslOperatorType` | `OR`, `AND` |
 | `DslSortDirectionType` | `ASC`, `DESC` |
 | `ComponentType` | `page`, `layout`, `image`, `part`, `text`, `fragment` |
+| `HighlightEncoderType` | `default`, `html` |
+| `HighlightFragmenterType` | `simple`, `span` |
+| `HighlightOrderType` | `score`, `none` |

--- a/skills/enonic-guillotine-query-builder/references/troubleshooting.md
+++ b/skills/enonic-guillotine-query-builder/references/troubleshooting.md
@@ -76,8 +76,17 @@ queryDsl(
 
 | Symptom | Fix |
 |---|---|
-| Custom field not appearing | Verify the `creationCallbacks` key matches the exact generated type name. Use Query Playground introspection to confirm. |
-| Type not found in dictionary | Ensure `context.dictionary` is passed to `createSchema`. |
+| Custom field not appearing | In Guillotine 7, use `exports.extensions` in `guillotine/guillotine.js`. For 6.x, verify the `creationCallbacks` key matches the exact generated type name. Use Query Playground introspection to confirm. |
+| Type not found in dictionary | Ensure `context.dictionary` is passed to `createSchema` (6.x only). In Guillotine 7, types are registered through the Extensions API. |
+
+## Guillotine 7 Migration Issues
+
+| Symptom | Fix |
+|---|---|
+| `params` argument type error on `pageUrl` | In Guillotine 7, `params` is `Json` type, not `String`. Update the argument type. |
+| Subscriptions not working | GraphQL subscriptions are removed in Guillotine 7. Implement a custom solution. |
+| `siteConfig` not available | Site configuration is no longer obtainable from `dataAsJson`, `site`, or `portal_Site.dataAsJson` fields in Guillotine 7. |
+| URLs changed from relative to absolute | Guillotine 7 generates absolute (server) URLs by default for all URL fields and `processedHtml`. Adjust client URL handling. |
 
 ## Debugging Steps
 


### PR DESCRIPTION
- Add Guillotine 7.x as current stable version in compatibility reference
- Document Guillotine 7 breaking changes (subscriptions removed, params type change, site config removal, absolute URLs by default)
- Add Guillotine 7 Updates 1-3 (siteKey argument, NPM types, CORS, maxQueryTokens)
- Add missing Content interface fields (creator, modifier, owner, xAsJson, pageAsJson, pageTemplate, site, permissions)
- Document boost parameter on DSL expression types
- Add subAggregations support to AggregationInput
- Expand Highlight input types with tagsSchema, fragmenter, noMatchSize, order, and per-property overrides
- Add imageSizes to ProcessHtmlInput for responsive images
- Add macrosAsJson, MediaIntentType, and link media/content distinction to RichText reference
- Add Guillotine 7 migration troubleshooting section
- Update SKILL.md version detection and validation steps for Guillotine 7