### PR TITLE
docs: update enonic-content-migration from latest Enonic docs

### DIFF
--- a/skills/enonic-content-migration/SKILL.md
+++ b/skills/enonic-content-migration/SKILL.md
@@ -55,7 +55,7 @@ metadata:
 
 **Step 5: Handle branch operations and publishing**
 1. Run content modifications in the `draft` branch context.
-2. After modifications complete, publish changed items to `master` using `contentLib.publish()` with `sourceBranch: 'draft'` and `targetBranch: 'master'`.
+2. After modifications complete, publish changed items to `master` using `contentLib.publish()`. On XP < 7.12, pass `sourceBranch: 'draft'` and `targetBranch: 'master'`. On XP 7.12+, these parameters are ignored (publish always goes draft→master).
 3. Set `includeDependencies: false` when publishing bulk-updated items to avoid unintended dependency publishing.
 4. For operations comparing draft and master state, use `repo.diff()` from `lib-node` with `target: 'master'` and `includeChildren: true`.
 
@@ -65,6 +65,7 @@ metadata:
 3. Read `assets/task-migration.template.ts` for the reusable task controller template with progress reporting.
 4. Check for existing running instances with `taskLib.isRunning()` before starting a duplicate operation.
 5. Use `taskLib.sleep()` for throttling between batches if the operation generates excessive load.
+6. For named tasks on XP 7.13+, the `run` function receives `taskId` as its second argument: `exports.run = function(params, taskId) { ... }`.
 
 **Step 7: Validate and report results**
 1. After the operation completes, log a summary: items processed, items created/updated/deleted, items failed, total duration.

--- a/skills/enonic-content-migration/references/compatibility.md
+++ b/skills/enonic-content-migration/references/compatibility.md
@@ -7,7 +7,7 @@
 | `contentLib.query()` | 6.0 | Core function, always available |
 | `contentLib.create()` | 6.0 | `refresh` parameter available from 6.0 |
 | `contentLib.modify()` | 6.0 | Editor callback pattern |
-| `contentLib.publish()` | 6.0 | `sourceBranch`/`targetBranch` deprecated since 7.13 (still works) |
+| `contentLib.publish()` | 6.0 | `sourceBranch`/`targetBranch` not in use since 7.12 (ignored, publish always goes draft→master). `excludeChildrenIds` parameter added in 7.12 |
 | `contentLib.archive()` | 7.8 | Archive/restore workflow |
 | `contentLib.restore()` | 7.8 | Restore from archive |
 | `contentLib.duplicate()` | 7.12 | Includes `variant` option from 7.12 |
@@ -15,6 +15,11 @@
 | `taskLib.submitTask()` | 7.7 | Replaces deprecated `taskLib.submitNamed()` |
 | `taskLib.sleep()` | 7.0 | Only works inside a task context |
 | `repo.duplicate()` | 7.12 | Node-level duplication |
+| `repo.findChildren()` `recursive` | 7.7 | Recursive fetching of all nested children |
+| Named task `taskId` 2nd argument | 7.13 | `exports.run(params, taskId)` receives task ID |
+| `lib-export` (exportNodes/importNodes) | 7.8 | Node export/import API for environment migration |
+| Query DSL `exists` expression | 7.11 | DSL expression to check field existence |
+| Query DSL `boolean.filter` | 7.11 | Non-scoring filter compound in query DSL |
 | Query DSL (JSON format) | 7.9 | Alternative to string-based NoQL |
 | Sort DSL (JSON format) | 7.9 | Alternative to string-based sort |
 | Min/Max/Value Count aggregations | 7.7 | Standalone metric aggregations |

--- a/skills/enonic-content-migration/references/examples.md
+++ b/skills/enonic-content-migration/references/examples.md
@@ -415,7 +415,8 @@ contextLib.run({
   repo.push({
     keys: result.hits.map(h => h.id),
     target: 'master',
-    resolve: false
+    resolve: false,
+    includeChildren: false  // Set true to also push child nodes
   });
 
   repo.refresh();

--- a/skills/enonic-content-migration/references/migration-reference.md
+++ b/skills/enonic-content-migration/references/migration-reference.md
@@ -48,8 +48,13 @@ contentLib.create({
   displayName: 'Item Name',    // Display name
   contentType: 'app:typeName', // Required content type
   language: 'en',              // Optional language tag
+  childOrder: '_ts DESC',      // Optional default child ordering
   data: {},                    // Content data object
   x: {},                       // eXtra data (x-data)
+  workflow: {                  // Optional workflow state (default: READY)
+    state: 'READY',
+    checks: {}
+  },
   requireValid: true,          // Validate against content type (default: true)
   refresh: true                // Index refresh — set false for bulk operations
 });
@@ -71,13 +76,16 @@ contentLib.modify({
 
 ### Publish Pattern
 
+> **XP 7.12+ change:** `sourceBranch` and `targetBranch` are no longer in use. Publish always pushes from `draft` to `master`. These parameters are silently ignored on XP 7.12+. Keep them for backward compatibility with XP < 7.12.
+
 ```typescript
 contentLib.publish({
   keys: ['/site/page1', 'content-id-2'],
-  sourceBranch: 'draft',
-  targetBranch: 'master',
-  includeDependencies: false,  // Set false for bulk to avoid cascade
-  schedule: {                  // Optional scheduling
+  sourceBranch: 'draft',              // Ignored on XP 7.12+
+  targetBranch: 'master',             // Ignored on XP 7.12+
+  includeDependencies: false,          // Set false for bulk to avoid cascade
+  excludeChildrenIds: ['id-3'],        // Exclude descendants of specific items (XP 7.12+)
+  schedule: {                          // Optional scheduling
     from: new Date().toISOString(),
     to: '2025-12-31T23:59:59Z'
   }
@@ -110,7 +118,8 @@ const repo = connect({
 | `repo.diff()` | Compare node versions across branches |
 | `repo.exists()` | Check node existence |
 | `repo.get()` | Fetch nodes by id or path |
-| `repo.findChildren()` | Fetch children with pagination |
+| `repo.findChildren()` | Fetch children with pagination; supports `recursive` (XP 7.7+) and `countOnly` options |
+| `repo.findVersions()` | Fetch version history of a node |
 | `repo.refresh()` | Refresh indices after bulk updates |
 
 ## NoQL Query DSL Reference
@@ -371,9 +380,10 @@ Place in `src/main/resources/tasks/{taskName}/{taskName}.js`:
 ```typescript
 import { progress } from '/lib/xp/task';
 
-exports.run = function(params) {
+exports.run = function(params, taskId) {
   // params come from submitTask config
-  progress({ info: 'Starting', current: 0, total: params.total });
+  // taskId is provided as second argument (XP 7.13+)
+  progress({ info: 'Starting ' + taskId, current: 0, total: params.total });
   // ... processing ...
 };
 ```
@@ -387,4 +397,38 @@ submitTask({
   descriptor: 'myMigrationTask',
   config: { query: targetQuery, batchSize: 100 }
 });
+```
+
+## Export/Import API (lib-export, XP 7.8+)
+
+For environment-level migration (moving content between XP instances), use the dedicated export/import API.
+
+### Import
+
+```typescript
+import exportLib from '/lib/xp/export';
+```
+
+### Export Nodes
+
+```typescript
+exportLib.exportNodes({
+  sourceNodePath: '/content',
+  exportName: 'my-export',
+  includeNodeIds: true,
+  includeVersions: false
+});
+// Export is written to the server's exports directory
+```
+
+### Import Nodes
+
+```typescript
+exportLib.importNodes({
+  source: 'my-export',           // Export name in exports directory
+  targetNodePath: '/content',
+  includeNodeIds: true,           // Preserve original IDs (default: false)
+  includePermissions: true        // Preserve permissions (default: false)
+});
+// Returns: { addedNodes, updatedNodes, importedBinaries, importErrors }
 ```


### PR DESCRIPTION
- Update publish API: sourceBranch/targetBranch not in use since XP 7.12, add excludeChildrenIds parameter
- Add named task taskId second argument (XP 7.13+)
- Add lib-export (exportNodes/importNodes) API reference (XP 7.8+)
- Add workflow and childOrder parameters to contentLib.create()
- Add repo.findChildren() recursive and repo.findVersions() to node API
- Add repo.push() includeChildren parameter to examples
- Add Query DSL exists expression and boolean.filter (XP 7.11+) to compatibility table