### PR TITLE
docs: update enonic-controller-generator from latest Enonic docs

### DIFF
--- a/skills/enonic-controller-generator/SKILL.md
+++ b/skills/enonic-controller-generator/SKILL.md
@@ -69,6 +69,7 @@ description: Generates Enonic XP controller files (TypeScript/JavaScript) and pa
    - `com.enonic.xp:lib-content:${xpVersion}` — if the controller uses content queries.
    - `com.enonic.lib:lib-thymeleaf:2.0.0` — if using Thymeleaf rendering.
    - `com.enonic.lib:lib-mustache:2.1.0` — if using Mustache rendering.
+   - `com.enonic.lib:lib-asset:${libVersion}` — if the controller generates asset URLs (replaces the deprecated `portalLib.assetUrl` in XP 7.15+).
 
 **Step 9: Validate Output**
 1. Verify the descriptor file name matches the parent directory name exactly.

--- a/skills/enonic-controller-generator/references/compatibility.md
+++ b/skills/enonic-controller-generator/references/compatibility.md
@@ -5,7 +5,8 @@
 - **XP 7.x**: Current stable branch. All patterns in this skill target XP 7.x.
 - **XP 7.2+**: Custom icons for parts (SVG or PNG placed alongside the descriptor).
 - **XP 7.8+**: `archive` and `restore` functions in lib-content.
-- **XP 7.15+**: `assetUrl` from lib-portal is deprecated; use `lib-asset` or `lib-static` instead.
+- **XP 7.12+**: `request.getHeader(name)` for case-insensitive header lookup. `duplicate` function in lib-content.
+- **XP 7.15+**: `assetUrl` from lib-portal is deprecated; use `lib-asset` or `lib-static` instead. `patch` HTTP method supported in controllers. Response headers can be set to `null` to remove headers added by other controllers/filters.
 
 ## TypeScript vs JavaScript
 
@@ -38,6 +39,7 @@ Enonic XP supports both TypeScript and JavaScript controllers.
 | lib-content | `/lib/xp/content` | `com.enonic.xp:lib-content:${xpVersion}` |
 | lib-thymeleaf | `/lib/thymeleaf` | `com.enonic.lib:lib-thymeleaf:2.0.0` |
 | lib-mustache | `/lib/mustache` | `com.enonic.lib:lib-mustache:2.1.0` |
+| lib-asset | `/lib/enonic/asset` | `com.enonic.lib:lib-asset:${libVersion}` |
 
 ## Common Pitfalls
 

--- a/skills/enonic-controller-generator/references/controller-reference.md
+++ b/skills/enonic-controller-generator/references/controller-reference.md
@@ -31,15 +31,21 @@ Controllers export named functions matching HTTP methods:
 // TypeScript style
 export function get(req: Request): Response { ... }
 export function post(req: Request): Response { ... }
+export function delete(req: Request): Response { ... }
+export function patch(req: Request): Response { ... }  // XP 7.15+
 ```
 
 ```js
 // JavaScript (CommonJS) style
 exports.get = function (req) { ... };
 exports.post = function (req) { ... };
+exports.delete = function (req) { ... };
+exports.patch = function (req) { ... };  // XP 7.15+
 ```
 
 A special `all` export handles any HTTP method not explicitly declared.
+
+Supported methods: `get`, `post`, `put`, `delete`, `head`, `options`, and `patch` (XP 7.15+).
 
 The handler receives an HTTP Request object and must return an HTTP Response object:
 
@@ -52,6 +58,40 @@ export function get(req) {
   };
 }
 ```
+
+### Request Object Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `method` | string | HTTP method (GET, POST, etc.) |
+| `scheme` | string | `http` or `https` |
+| `host` | string | Server host name |
+| `port` | string | Server port |
+| `path` | string | Request path |
+| `url` | string | Full request URL |
+| `remoteAddress` | string | Client IP (respects `X-Forwarded-For`) |
+| `mode` | string | Rendering mode: `inline`, `edit`, `preview`, `live` |
+| `branch` | string | Repository branch: `draft` or `master` |
+| `body` | string | Optional request body |
+| `params` | object | Query/form parameters |
+| `headers` | object | HTTP request headers |
+| `cookies` | object | HTTP request cookies |
+
+Since XP 7.12, the request object also exposes `getHeader(name)` — a case-insensitive header lookup function. Prefer it over accessing `headers` directly.
+
+### Response Object Properties
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `status` | number | `200` | HTTP status code |
+| `body` | string/object | | Response body |
+| `contentType` | string | `text/plain; charset=utf-8` | MIME type |
+| `headers` | object | | Response headers (value can be `null` to remove a header, XP 7.15+) |
+| `cookies` | object | | Response cookies |
+| `redirect` | string | | URI to redirect to (sets status 303) |
+| `postProcess` | boolean | `true` | Site engine: process component placeholder tags in the body |
+| `pageContributions` | object | | Site engine: contribute HTML to specific positions in the response |
+| `applyFilters` | boolean | `true` | Site engine: if `false`, skip response processors and filters |
 
 ## Portal API (lib-portal)
 
@@ -72,12 +112,14 @@ dependencies {
 | `getComponent()` | part, layout | Returns the current component (config, regions) as JSON |
 | `getSite()` | page, part, layout | Returns the parent site as JSON |
 | `getSiteConfig()` | page, part, layout | Returns the site config for the current app |
-| `assetUrl({path})` | any | Generates URL to a static asset file |
+| `assetUrl({path})` | any | Generates URL to a static asset — **deprecated in XP 7.15**, use `lib-asset` or `lib-static` instead |
+| `attachmentUrl({id, name})` | any | Generates URL to a content attachment |
 | `imageUrl({id, scale})` | any | Generates URL to an image |
 | `pageUrl({path})` | any | Generates URL to a content page |
 | `componentUrl({component})` | any | Generates URL to a page component |
 | `serviceUrl({service})` | any | Generates URL to a service |
-| `processHtml({value})` | any | Resolves internal links in HTML content |
+| `processHtml({value})` | any | Resolves internal links in HTML content. Supports `imageWidths` (XP 7.7+) and `imageSizes` (XP 7.8+) for responsive images |
+| `sanitizeHtml(html)` | any | Strips unsafe tags/attributes to protect against XSS |
 
 ### Example — getComponent() Return Value (Layout)
 
@@ -152,6 +194,25 @@ const body = mustacheLib.render(view, model);
 return { body, contentType: 'text/html' };
 ```
 
+## Page Contributions
+
+Any component controller (page, part, layout) can add `pageContributions` to the response to inject content into the rendered page at four positions: `headBegin`, `headEnd`, `bodyBegin`, `bodyEnd`.
+
+```ts
+export function get(req) {
+  return {
+    body: '<div>My part</div>',
+    contentType: 'text/html',
+    pageContributions: {
+      headEnd: '<link rel="stylesheet" href="styles.css"/>',
+      bodyEnd: ['<script src="main.js"></script>']
+    }
+  };
+}
+```
+
+Duplicate contributions are automatically removed during the merge step. If the target tag (e.g., `<head>`) does not exist in the response, contributions to that position are ignored.
+
 ## Response Processors
 
 Place controller files at: `src/main/resources/site/processors/<name>.js`
@@ -167,6 +228,10 @@ exports.responseProcessor = function (req, res) {
   return res;
 };
 ```
+
+Response processors run between component rendering and the contributions filter. Setting `applyFilters: false` in the response skips further processors and filters.
+
+Execution order is determined by the `order` attribute (lower = higher priority) combined with app order on the site.
 
 Register in `site.xml`:
 ```xml


### PR DESCRIPTION
- Add patch/delete HTTP methods and full list of supported methods (XP 7.15+)
- Add request and response object property tables with version annotations
- Mark assetUrl as deprecated (XP 7.15), add lib-asset as replacement
- Add attachmentUrl, sanitizeHtml, processHtml extra params to Portal API
- Add page contributions section for component controllers
- Document response processor execution order and applyFilters
- Add XP 7.12+ features: getHeader(), duplicate()
- Add lib-asset to library versions table